### PR TITLE
Rename NAM source option to NAM218

### DIFF
--- a/src/forecast.py
+++ b/src/forecast.py
@@ -1561,7 +1561,7 @@ def verify_inputs(args,sys_cfg):
                 raise OSError(err % args[key])
 
     # check for valid grib source
-    available_grib_sources = ['HRRR', 'RAP', 'RRFS', 'RRFSNA', 'NAM218', 'NAM227', 'NARR', 'CFSR', 'GFSA', 'GFSF']
+    available_grib_sources = ['HRRR', 'RAP', 'RRFS', 'RRFSNA', 'NAM', 'NAM218', 'NAM227', 'NARR', 'CFSR', 'GFSA', 'GFSF']
     if 'grib_source' in args:
         if args['grib_source'] not in available_grib_sources:
             raise ValueError('Invalid grib source %s, must be one of %s' % (args['grib_source'], ', '.join(available_grib_sources)))

--- a/src/forecast.py
+++ b/src/forecast.py
@@ -1561,7 +1561,7 @@ def verify_inputs(args,sys_cfg):
                 raise OSError(err % args[key])
 
     # check for valid grib source
-    available_grib_sources = ['HRRR', 'RAP', 'RRFS', 'RRFSNA', 'NAM', 'NAM227', 'NARR', 'CFSR', 'GFSA', 'GFSF']
+    available_grib_sources = ['HRRR', 'RAP', 'RRFS', 'RRFSNA', 'NAM218', 'NAM227', 'NARR', 'CFSR', 'GFSA', 'GFSF']
     if 'grib_source' in args:
         if args['grib_source'] not in available_grib_sources:
             raise ValueError('Invalid grib source %s, must be one of %s' % (args['grib_source'], ', '.join(available_grib_sources)))

--- a/src/ingest/retrieve_gribs.py
+++ b/src/ingest/retrieve_gribs.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
         grib_src = HRRR_S(js)
     elif grib_src_name == 'HRRR':
         grib_src = HRRR(js)
-    elif grib_src_name == 'NAM':
+    elif grib_src_name == 'NAM218':
         grib_src = NAM218(js)
     elif grib_src_name == 'NAM227':
         grib_src = NAM227(js)

--- a/src/ingest/retrieve_gribs.py
+++ b/src/ingest/retrieve_gribs.py
@@ -42,7 +42,7 @@ import os.path as osp
 if __name__ == '__main__':
     if len(sys.argv) != 5:
         print(('Usage: %s <grib_source_name> <esmf_from_utc> <esmf_to_utc> <target_directory>' % sys.argv[0]))
-        print('       supported GRIB sources: HRRR_S, HRRR, NAM, CFSR_P, CFSR_S, NARR, GFSA, GFSF_P, GFSF_S, RAP, RRFS_CONUS_P, RRFS_CONUS_S, RRFS_NA_P, RRFS_NA_S')
+        print('       supported GRIB sources: HRRR_S, HRRR, NAM (NAM218), NAM227, CFSR_P, CFSR_S, NARR, GFSA, GFSF_P, GFSF_S, RAP, RRFS_CONUS_P, RRFS_CONUS_S, RRFS_NA_P, RRFS_NA_S')
         sys.exit(-1)
 
 
@@ -61,7 +61,7 @@ if __name__ == '__main__':
         grib_src = HRRR_S(js)
     elif grib_src_name == 'HRRR':
         grib_src = HRRR(js)
-    elif grib_src_name == 'NAM218':
+    elif grib_src_name == 'NAM' or 'NAM218':
         grib_src = NAM218(js)
     elif grib_src_name == 'NAM227':
         grib_src = NAM227(js)


### PR DESCRIPTION
## Summary
Changes the NAM GRIB source name to `NAM218`.

## Changes
- Replaces `NAM` with `NAM218` in the list of valid GRIB sources.
- Updates the download code to look for `NAM218`.

This matches the source name with the existing `NAM218` code and distinguishes it from `NAM227`.

## Testing
Ran a forecast using `NAM218` as the GRIB source and confirmed it was accepted correctly.