### PR TITLE
Removed progress status from aws call

### DIFF
--- a/src/ingest/downloader.py
+++ b/src/ingest/downloader.py
@@ -125,6 +125,7 @@ def download_url(url, local_path, max_retries=max_retries_def, sleep_seconds=sle
         command=['aws','s3','cp',url,ensure_dir(local_path)]
         if token is None:
             command.append('--no-sign-request')
+        command.append('--no-progress')
     else:
         command=[wget,'-O',ensure_dir(local_path),url]
         for opt in wget_options:


### PR DESCRIPTION
## Summary

Disables AWS CLI progress output during GRIB downloads to prevent noisy logs.

## Changes

- Adds the AWS CLI `--no-progress` option to download commands.

## Testing

- Ran GRIB downloads successfully.
- Confirmed progress output no longer appears in the logs.